### PR TITLE
Update `kill` call to take the PID instead of a file path

### DIFF
--- a/jobs/statsd-injector/templates/statsd-injector-ctl.erb
+++ b/jobs/statsd-injector/templates/statsd-injector-ctl.erb
@@ -24,7 +24,7 @@ case $1 in
     ;;
 
   stop)
-    kill $PIDFILE
+    kill "$(cat $PIDFILE)"
 
     ;;
 


### PR DESCRIPTION
According to the manpage, the argument to the `kill` command should be the PID itself, not a path to a file containing the PID.

This PR just cats the PIDFILE out as the argument to `kill`