### PR TITLE
Provides fallback to deployment property

### DIFF
--- a/jobs/statsd_injector/spec
+++ b/jobs/statsd_injector/spec
@@ -21,6 +21,7 @@ properties:
     default: 8125
   statsd_injector.deployment:
     description: "The name of the deployment, used for 'deployment' tag on outgoing envelopes"
+    default: ""
     example: "cf,cf-warden"
 
   loggregator.tls.ca_cert:

--- a/jobs/statsd_injector/templates/ctl.erb
+++ b/jobs/statsd_injector/templates/ctl.erb
@@ -24,7 +24,7 @@ case $1 in
         --ca="$certs/ca.crt" \
         --cert="$certs/statsd_injector.crt" \
         --key="$certs/statsd_injector.key" \
-        --deployment-name="<%= p("statsd_injector.deployment") %>" \
+        --deployment-name="<%=p("statsd_injector.deployment").empty? ? spec.deployment : p("statsd_injector.deployment")%>" \
         --job-name="<%= spec.name %>" \
         --instance-index="<%= spec.id || spec.index %>" \
         --ip="<%= spec.ip %>" &


### PR DESCRIPTION
Does not force the user to specify a `statsd_injector.deployment` property.
If the user doesn't provide one, it will fall back to `spec.deployment` bosh
property.

[#146111437]