### PR TITLE
Include CI pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ Examples of loggregator v2 envelope receiver:
 A visual of how it fits in the broader loggregator architecture can be found
 in the [Loggregator Architecture docs](https://docs.cloudfoundry.org/loggregator/architecture.html).
 
+For example, this is used in CF by the components UAA and CAPI.
+
 ### Development
 
 The binary for `statsd_injector` is build from the code is `src/`. To run the
@@ -109,10 +111,10 @@ bosh create-release
 1. Validate the metric can be seen.
 
    Assuming you are using `statsd-injector` with CF Release, you can use the
-   [CF Nozzle plugin][cf-nozzle-plugin]
+   [CF Log Stream plugin][cf-log-stream-plugin]
 
    ```bash
-   cf nozzle -filter CounterEvent | grep <metric_name>
+   cf log-stream <source-id> | grep <metric_name>
    ```
 
    Alternatively, you could curl the metrics-agent endpoint directly:
@@ -121,9 +123,29 @@ bosh create-release
    curl https://localhost:14727/metrics -k -cacert=scrape_ca.crt --cert scrape.crt --key scrape.key
    ```
 
+### Pipeline
+
+The Concourse pipeline configuration and set-up script live in the
+[ci directory](https://github.com/cloudfoundry/statsd-injector-release/tree/develop/ci).
+
+View the pipeline [here](https://concourse.cf-denver.com/teams/loggregator/pipelines/statsd-injector?group=statsd-injector).
+
+To update the pipeline, you can run `ci/set-pipeline.sh statsd-injector`.
+
+The pipeline has 4 groups:
+* Claims an environment
+* Run statsd-injector-release tests
+    * Bumps Go modules and runs unit tests
+    * Creates a deploys a dev release to CF-D
+    * Tests against cfar-lats
+    * Merges changes to release-elect and master branch when changes are
+      accepted
+* Cuts a release
+* Bumps golang dependency
+
 [loggregator-api]:         https://github.com/cloudfoundry/loggregator-api
 [grpc]:                    https://github.com/grpc/
 [bosh-release]:            http://bosh.io/releases/github.com/cloudfoundry/statsd-injector-release?all=1
 [datadog-statsd]:          https://docs.datadoghq.com/developers/dogstatsd/datagram_shell/
-[cf-nozzle-plugin]:        https://github.com/cloudfoundry-community/firehose-plugin
+[cf-log-stream-plugin]:    https://github.com/cloudfoundry/log-stream-cli
 [forwarder-agent-release]: https://github.com/cloudfoundry/loggregator-agent-release

--- a/ci/pipelines/config/config.yml
+++ b/ci/pipelines/config/config.yml
@@ -1,0 +1,1 @@
+toolsmiths-workers-tag: cf-denver-shared-vsphere

--- a/ci/pipelines/products.yml.erb
+++ b/ci/pipelines/products.yml.erb
@@ -1,0 +1,404 @@
+<%
+bosh_releases = %w(statsd-injector)
+cfd_smoke_tests = %w(cats cfar-lats)
+
+smoke_tests = {
+  "statsd-injector" => cfd_smoke_tests,
+}
+
+clis = {
+  "cf-drain" => "code.cloudfoundry.org/cf-drain-cli",
+}
+%>
+groups:
+- name: all
+  jobs:
+  - cf-deploy
+  - cfar-lats
+  - cats
+  - test-releases-can-be-exported
+<% bosh_releases.each do |release| %>
+  - <%= release %>-tests-with-bumped-modules
+  - <%= release %>-promotion
+  - <%= release %>-master-promotion
+<% end %>
+<% bosh_releases.each do |release| %>
+- name: <%= release %>
+  jobs:
+  - <%= release %>-tests-with-bumped-modules
+  - cf-deploy
+  - cfar-lats
+  - cats
+  - test-releases-can-be-exported
+  - <%= release %>-promotion
+  - <%= release %>-master-promotion
+  <% if release == "log-cache" %>
+  - lcats
+  <% end %>
+  <% if release == "metrics-discovery" %>
+  - test-metrics-agent
+  - metrics-smoke-test
+  <% end %>
+<% end %>
+resources:
+- name: 5m
+  type: time
+  source:
+    interval: 5m
+
+- name: 24h
+  type: time
+  source:
+    interval: 24h
+
+- name: cf-acceptance-tests
+  type: git
+  source:
+    branch: master
+    uri: https://github.com/cloudfoundry/cf-acceptance-tests.git
+
+- name: cf-deployment
+  type: git
+  source:
+    uri: https://github.com/cloudfoundry/cf-deployment
+    branch: master
+    private_key: ((loggregator-key))
+
+- name: cf-deployment-concourse-tasks
+  type: git
+  source:
+    uri: https://github.com/cloudfoundry/cf-deployment-concourse-tasks
+    tag_filter: v*
+
+- name: concourse-tasks
+  type: git
+  source:
+    branch: master
+    uri: https://github.com/pivotal-cf/concourse-tasks
+
+- name: cfar-logging-acceptance-tests
+  type: git
+  source:
+    branch: master
+    uri: https://github.com/cloudfoundry/cfar-logging-acceptance-tests.git
+
+- name: deployments-loggregator
+  type: git
+  source:
+    uri: git@github.com:cloudfoundry/deployments-loggregator.git
+    branch: master
+    private_key: ((deployments-loggregator-key))
+
+- name: denver-deployments
+  type: git
+  source:
+    uri: git@github.com:pivotal-cf/denver-deployments.git
+    branch: master
+    private_key: ((cf-loggregator-oauth-bot-key))
+
+- name: loggregator-ci
+  type: git
+  source:
+    uri: git@github.com:cloudfoundry/loggregator-ci
+    branch: master
+    private_key: ((cf-loggregator-oauth-bot-key))
+
+- name: cf-deployment-concourse-tasks-image
+  type: docker-image
+  source:
+    repository: relintdockerhubpushbot/cf-deployment-concourse-tasks
+    tag: latest
+
+<% (bosh_releases).each do |release| %>
+- name: <%= release %>-release-elect
+  type: git
+  source:
+    uri: git@github.com:cloudfoundry/<%= release %>-release.git
+    branch: release-elect
+    private_key: ((cf-loggregator-oauth-bot-key))
+    ignore_paths:
+      - .final_builds
+      - releases
+
+- name: <%= release %>-release
+  type: git
+  source:
+    uri: git@github.com:cloudfoundry/<%= release %>-release.git
+    branch: develop
+    private_key: ((cf-loggregator-oauth-bot-key))
+    ignore_paths:
+      - .final_builds
+      - releases
+
+- name: <%= release %>-release-master
+  type: git
+  source:
+    uri: git@github.com:cloudfoundry/<%= release %>-release.git
+    branch: master
+    private_key: ((cf-loggregator-oauth-bot-key))
+    disable_ci_skip: true
+<% end %>
+<% clis.each_key do |cli| %>
+- name: <%= cli %>-cli-master
+  type: git
+  source:
+    uri: git@github.com:cloudfoundry/<%= cli %>-cli
+    branch: master
+    private_key: ((cf-loggregator-oauth-bot-key))
+<% end %>
+jobs:
+###############################################################################
+# BOSH RELEASES
+###############################################################################
+<% (bosh_releases).each do |release| %>
+- name: <%= release %>-tests-with-bumped-modules
+  public: true
+  serial: true
+  plan:
+  - in_parallel:
+    - get: loggregator-ci
+    - get: 24h
+      trigger: true
+    - get: <%= release %>-release
+      trigger: true
+  - in_parallel:
+    - task: run-tests
+      file: loggregator-ci/tasks/go-bump-modules-and-test/task.yml
+      input_mapping:
+        source-repo: <%= release %>-release
+  - task: commit
+    file: loggregator-ci/tasks/commit/task.yml
+    input_mapping:
+      release-repo: bumped-source
+    output_mapping:
+      committed-repo: committed-<%= release %>-release
+    params:
+      COMMIT_MESSAGE: "Bump modules"
+  - put: <%= release %>-release
+    params:
+      repository: committed-<%= release %>-release
+      rebase: true
+
+- name: <%= release %>-promotion
+  serial: true
+  plan:
+  - in_parallel:
+    - get: develop
+      resource: <%= release %>-release
+      trigger: true
+      passed: <%= smoke_tests[release] + ["test-releases-can-be-exported"] %>
+    - get: <%= release %>-release-elect
+  - put: <%= release %>-release-elect
+    params:
+      repository: develop
+
+- name: <%= release %>-master-promotion
+  serial: true
+  plan:
+  - in_parallel:
+    - get: 5m
+      trigger: true
+    - get: <%= release %>-release-elect
+      passed: ["<%= release %>-promotion"]
+      trigger: true
+    - get: <%= release %>-release-master
+    - get: loggregator-ci
+  - task: bumper
+    file: loggregator-ci/tasks/bumper/task.yml
+    input_mapping:
+      source: <%= release %>-release-elect
+      dest: <%= release %>-release-master
+    params:
+      SOURCE_BRANCH: release-elect
+      DEST_BRANCH: master
+      TRACKER_API_TOKEN: ((tracker-api-token))
+  - put: <%= release %>-release-master
+    params:
+      repository: merged-dest
+<% end %>
+
+- name: cf-deploy
+  serial: true
+  serial_groups:
+  - cf-deploy
+  - bosh-cf-cats
+  - bosh-cfar-lats
+  - bosh-export-releases
+  plan:
+  - in_parallel:
+    - get: loggregator-ci
+    - get: denver-deployments
+    - get: bbl-state
+      resource: deployments-loggregator
+    - get: cf-deployment
+      trigger: true
+    - get: cf-deployment-concourse-tasks
+    <% bosh_releases.each do |release| %>
+    - get: <%= release %>-release
+      passed: ["<%= release %>-tests-with-bumped-modules"]
+      trigger: true
+    <% end %>
+  - in_parallel:
+    <% bosh_releases.each do |release| %>
+    - task: upload-<%= release %>-release
+      file: loggregator-ci/tasks/upload-release/task.yml
+      input_mapping:
+        bosh-release-dir: <%= release %>-release
+      params:
+        BBL_STATE_DIR: ((acceptance_bbl_state_dir))
+    <% end %>
+  - task: copy-ops-files
+    file: loggregator-ci/tasks/prepare-cf-ops/task.yml # TODO: check out what this task does
+    params:
+      BBL_STATE_DIR: ((acceptance_bbl_state_dir))
+  - task: cf-deploy
+    file: cf-deployment-concourse-tasks/bosh-deploy/task.yml
+    input_mapping:
+      vars-files: bbl-state
+    params:
+      BBL_STATE_DIR: ((acceptance_bbl_state_dir))
+      SYSTEM_DOMAIN: ((acceptance_system_domain))
+      OPS_FILES: |
+        scale-to-one-az.yml
+        use-compiled-releases.yml
+        experimental/use-compiled-releases-windows.yml
+        use-provided-router-certs.yml
+        experimental/fast-deploy-with-downtime-and-danger.yml
+
+        experimental/use-logcache-syslog-ingress.yml
+
+        # TODO: look at denver ops files
+        denver/loggregator-clients.yml
+        denver/log-cache-acceptance.yml
+        denver/loggregator-acceptance.yml
+      VARS_FILES: ""
+  - task: enable-feature-flags
+    file: cf-deployment-concourse-tasks/set-feature-flags/task.yml
+    attempts: 3
+    params:
+      SYSTEM_DOMAIN: ((acceptance_system_domain))
+      BBL_STATE_DIR: ((acceptance_bbl_state_dir))
+      ENABLED_FEATURE_FLAGS: diego_docker
+  - task: cleanup
+    file: cf-deployment-concourse-tasks/bosh-cleanup/task.yml
+    params:
+      BBL_STATE_DIR: ((acceptance_bbl_state_dir))
+  - task: create-blackbox-space
+    file: loggregator-ci/tasks/create-org-and-space/task.yml
+    params:
+      BBL_STATE_DIR: ((acceptance_bbl_state_dir))
+      ORG: system
+      SPACE: blackbox-testing
+      SYSTEM_DOMAIN: ((acceptance_system_domain))
+  - task: create-accumulators-space
+    file: loggregator-ci/tasks/create-org-and-space/task.yml
+    params:
+      BBL_STATE_DIR: ((acceptance_bbl_state_dir))
+      ORG: system
+      SPACE: accumulators
+      SYSTEM_DOMAIN: ((acceptance_system_domain))
+
+- name: test-releases-can-be-exported
+  serial: true
+  serial_groups:
+  - bosh-export-releases
+  plan:
+  - in_parallel:
+    - get: concourse-tasks
+    - get: cf-deployment-concourse-tasks-image
+    - get: bbl-state
+      resource: deployments-loggregator
+    <% bosh_releases.each do |release| %>
+    - get: <%= release %>-release
+      trigger: true
+      passed: ["cf-deploy"]
+    <% end %>
+  - do:
+    - task: export-releases-xenial
+      file: concourse-tasks/release/export/task.yml
+      params:
+        BBL_STATE_DIR: ((acceptance_bbl_state_dir))
+        RELEASE_NAMES: |
+          <% (bosh_releases).each do |release| %><%= release %>
+          <% end %>
+    ensure:
+      task: clean-up
+      image: cf-deployment-concourse-tasks-image
+      config:
+        platform: linux
+        inputs:
+        - name: bbl-state
+        params:
+          BBL_STATE_DIR: ((acceptance_bbl_state_dir))
+        run:
+          path: /bin/bash
+          args:
+          - "-c"
+          - |
+            set -e
+            pushd "bbl-state/${BBL_STATE_DIR}" > /dev/null
+              eval "$(bbl print-env)"
+            popd > /dev/null
+
+            for deployment in $(bosh deployments --column Name | grep compilation-) ; do
+              bosh delete-deployment -d "$deployment" -n
+            done
+
+- name: cats
+  serial: true
+  serial_groups:
+  - bosh-cf-cats
+  plan:
+  - in_parallel:
+    - get: loggregator-ci
+    - get: cf-deployment-concourse-tasks
+    - get: deployments-loggregator
+    - get: cf-acceptance-tests
+    <% bosh_releases.each do |release| %>
+    - get: <%= release %>-release
+      trigger: true
+      passed: ["cf-deploy"]
+    <% end %>
+  - task: generate-config
+    file: loggregator-ci/tasks/generate-cats-config/task.yml
+    input_mapping:
+      bbl-state: deployments-loggregator
+    params:
+      BBL_STATE_DIR: ((acceptance_bbl_state_dir))
+      SYSTEM_DOMAIN: ((acceptance_system_domain))
+  - task: run-cats
+    file: cf-deployment-concourse-tasks/run-cats/task.yml
+    input_mapping:
+      integration-config: cats-config
+      cf-acceptance-tests: cf-acceptance-tests
+    params:
+      CONFIG_FILE_PATH: cats-config.json
+      NODES: 9
+
+- name: cfar-lats
+  serial: true
+  serial_groups:
+  - bosh-cfar-lats
+  plan:
+  - in_parallel:
+    - get: cfar-logging-acceptance-tests
+      trigger: true
+    - get: loggregator-ci
+    - get: bbl-state
+      resource: deployments-loggregator
+    - get: cf-drain-cli-master
+    <% bosh_releases.each do |release| %>
+    - get: <%= release %>-release
+      trigger: true
+      passed: ["cf-deploy"]
+    <% end %>
+  - task: run-cfar-lats
+    input_mapping:
+      cf-drain-cli: cf-drain-cli-master
+    file: loggregator-ci/tasks/cfar-lats/task.yml
+    params:
+      CF_ADMIN_USER: admin
+      CF_DOMAIN: ((acceptance_system_domain))
+      BBL_STATE_DIR: ((acceptance_bbl_state_dir))
+      SKIP_SSL_VALIDATION: true
+      APP_PUSH_TIMEOUT: 180s

--- a/ci/pipelines/statsd-injector.yml
+++ b/ci/pipelines/statsd-injector.yml
@@ -1,0 +1,708 @@
+groups:
+- name: claim-environment
+  jobs:
+  - claim-cfd-env
+  - unclaim-cfd-env
+- name: statsd-injector
+  jobs:
+  - statsd-injector-tests-with-bumped-modules
+  - cf-deploy
+  - cfar-lats
+  - test-releases-can-be-exported
+  - statsd-injector-promotion
+  - statsd-injector-master-promotion
+- name: release
+  jobs:
+  - statsd-injector-cut-major
+  - statsd-injector-cut-minor
+  - statsd-injector-cut-patch
+  - statsd-injector-bumper-check
+  - statsd-injector-create-final-release
+  - statsd-injector-merge-to-develop
+- name: bump-golang
+  jobs:
+  - bump-golang
+
+resource_types:
+- name: pcf-pool
+  type: docker-image
+  source:
+    repository: cftoolsmiths/toolsmiths-envs-resource
+
+resources:
+- name: 5m
+  type: time
+  source:
+    interval: 5m
+
+- name: 24h
+  type: time
+  source:
+    interval: 24h
+
+- name: cf-deployment
+  type: git
+  source:
+    uri: https://github.com/cloudfoundry/cf-deployment
+    tag_filter: v13.2.0
+    private_key: ((loggregator-key))
+
+- name: cf-deployment-concourse-tasks
+  type: git
+  source:
+    uri: https://github.com/cloudfoundry/cf-deployment-concourse-tasks
+    tag_filter: v10.18.0
+
+- name: concourse-tasks
+  type: git
+  source:
+    uri: https://github.com/pivotal-cf/concourse-tasks
+  version:
+    ref: 018663068fab25e0c76b6f72e08f322886dd6d04
+
+- name: cfar-logging-acceptance-tests
+  type: git
+  source:
+    branch: statsd-metrics # TODO: change back to master!
+    uri: https://github.com/cloudfoundry/cfar-logging-acceptance-tests.git
+
+- name: denver-deployments
+  type: git
+  source:
+    uri: git@github.com:pivotal-cf/denver-deployments.git
+    branch: master
+    private_key: ((cf-loggregator-oauth-bot-key))
+
+- name: loggregator-ci
+  type: git
+  source:
+    uri: git@github.com:cloudfoundry/loggregator-ci
+    branch: master
+    private_key: ((cf-loggregator-oauth-bot-key))
+
+- name: cf-deployment-concourse-tasks-image
+  type: docker-image
+  source:
+    repository: relintdockerhubpushbot/cf-deployment-concourse-tasks
+    tag: latest
+
+- name: statsd-injector-release-elect
+  type: git
+  source:
+    uri: git@github.com:cloudfoundry/statsd-injector-release.git
+    branch: release-elect
+    private_key: ((cf-loggregator-oauth-bot-key))
+    ignore_paths:
+      - .final_builds
+      - releases
+
+- name: statsd-injector-release
+  type: git
+  source:
+    uri: git@github.com:cloudfoundry/statsd-injector-release.git
+    branch: lts-pipeline # TODO: change me back to develop!
+    private_key: ((cf-loggregator-oauth-bot-key))
+    ignore_paths:
+      - .final_builds
+      - releases
+
+- name: statsd-injector-release-master
+  type: git
+  source:
+    uri: git@github.com:cloudfoundry/statsd-injector-release.git
+    branch: master
+    private_key: ((cf-loggregator-oauth-bot-key))
+    disable_ci_skip: true
+
+- name: cf-drain-cli-master
+  type: git
+  source:
+    uri: git@github.com:cloudfoundry/cf-drain-cli
+    branch: master
+    private_key: ((cf-loggregator-oauth-bot-key))
+
+- name: log-stream-cli-master
+  type: git
+  source:
+    uri: git@github.com:cloudfoundry/log-stream-cli
+    branch: master
+    private_key: ((cf-loggregator-oauth-bot-key))
+
+- name: cfd-env
+  type: pcf-pool
+  source:
+    api_token: ((toolsmiths-api-key))
+    hostname: environments.toolsmiths.cf-app.com
+    pool_name: cf-deployment
+  tags: [ ((toolsmiths-workers-tag)) ]
+
+
+#==========================================================================================
+#                         RESOURCES FOR RELEASING & DEPENDENCIES
+#==========================================================================================
+- name: statsd-injector-version
+  type: semver
+  source:
+    driver: git
+    uri: git@github.com:cloudfoundry/statsd-injector-release.git
+    branch: master
+    file: src/version
+    private_key: ((cf-loggregator-oauth-bot-key))
+
+- name: statsd-injector-release-to-cut
+  type: git
+  source:
+    uri: git@github.com:cloudfoundry/statsd-injector-release
+    branch: develop
+    private_key: ((cf-loggregator-oauth-bot-key))
+    disable_ci_skip: true
+    clean_tags: true
+
+- name: statsd-injector-release-master-to-cut
+  type: git
+  source:
+    uri: git@github.com:cloudfoundry/statsd-injector-release
+    branch: master
+    clean_tags: true
+    private_key: ((cf-loggregator-oauth-bot-key))
+
+- name: statsd-injector-release-master-version
+  type: git
+  source:
+    uri: git@github.com:cloudfoundry/statsd-injector-release
+    branch: master
+    clean_tags: true
+    private_key: ((cf-loggregator-oauth-bot-key))
+    paths:
+    - src/version
+
+- name: statsd-injector-github-release-drafts
+  type: github-release
+  source:
+    user: cloudfoundry
+    repository: statsd-injector-release
+    access_token: ((access-token))
+    drafts: true
+
+- name: statsd-injector-github-release-published
+  type: github-release
+  source:
+    user: cloudfoundry
+    repository: statsd-injector-release
+    access_token: ((access-token))
+
+- name: golang-release
+  type: git
+  source:
+    uri: git@github.com:bosh-packages/golang-release
+    branch: master
+    tag_filter: v*
+    private_key: ((cf-loggregator-oauth-bot-key))
+
+jobs:
+#==========================================================================================
+#                                     RUN TESTS
+#==========================================================================================
+- name: statsd-injector-tests-with-bumped-modules
+  public: true
+  serial: true
+  plan:
+  - in_parallel:
+    - get: loggregator-ci
+    - get: 24h
+      trigger: true
+    - get: statsd-injector-release
+      trigger: true
+  - in_parallel:
+    - task: run-tests
+      file: loggregator-ci/tasks/go-bump-modules-and-test/task.yml
+      input_mapping:
+        source-repo: statsd-injector-release
+  - task: commit
+    file: loggregator-ci/tasks/commit/task.yml
+    input_mapping:
+      release-repo: bumped-source
+    output_mapping:
+      committed-repo: committed-statsd-injector-release
+    params:
+      COMMIT_MESSAGE: "Bump modules"
+  - put: statsd-injector-release
+    params:
+      repository: committed-statsd-injector-release
+      rebase: true
+
+- name: statsd-injector-promotion
+  serial: true
+  plan:
+  - in_parallel:
+    - get: develop
+      resource: statsd-injector-release
+      trigger: true
+      passed: ["cfar-lats", "test-releases-can-be-exported"]
+    - get: statsd-injector-release-elect
+  - put: statsd-injector-release-elect
+    params:
+      repository: develop
+
+- name: statsd-injector-master-promotion
+  serial: true
+  plan:
+  - in_parallel:
+    - get: 5m
+      trigger: true
+    - get: statsd-injector-release-elect
+      passed: ["statsd-injector-promotion"]
+      trigger: true
+    - get: statsd-injector-release-master
+    - get: loggregator-ci
+  - task: bumper
+    file: loggregator-ci/tasks/bumper/task.yml
+    input_mapping:
+      source: statsd-injector-release-elect
+      dest: statsd-injector-release-master
+    params:
+      SOURCE_BRANCH: release-elect
+      DEST_BRANCH: master
+      TRACKER_API_TOKEN: ((tracker-api-token))
+  - put: statsd-injector-release-master
+    params:
+      repository: merged-dest
+
+- name: claim-cfd-env
+  serial: true
+  plan:
+  - in_parallel:
+    - get: cf-deployment
+    - get: cf-deployment-concourse-tasks
+    - get: concourse-tasks
+  - put: cfd-env
+    params:
+      action: claim
+    tags: [ ((toolsmiths-workers-tag)) ]
+  - task: output-env-details
+    file: concourse-tasks/toolsmiths/claim-pooled-env/task.yml
+    input_mapping:
+      pooled-env: cfd-env
+
+- name: cf-deploy
+  serial: true
+  serial_groups:
+  - cf-deploy
+  - bosh-cfar-lats
+  - bosh-export-releases
+  plan:
+  - in_parallel:
+    - get: cfd-env
+      tags: [ ((toolsmiths-workers-tag)) ]
+      passed: ["claim-cfd-env"]
+    - get: cf-deployment
+      trigger: true
+    - get: cf-deployment-concourse-tasks
+    - get: denver-deployments
+    - get: statsd-injector-release
+      passed: ["statsd-injector-tests-with-bumped-modules"]
+      trigger: true
+  - in_parallel:
+    - task: collect-ops-files
+      file: cf-deployment-concourse-tasks/collect-ops-files/task.yml
+      input_mapping:
+        base-ops-files: cf-deployment
+        new-ops-files: statsd-injector-release
+      params:
+        BASE_OPS_FILE_DIR: operations
+        NEW_OPS_FILES: manifests/operations/add-statsd-injector.yml
+    - task: empty-vars-files
+      config:
+        platform: linux
+        image_resource:
+          type: docker-image
+          source:
+            repository: relintdockerhubpushbot/cf-deployment-concourse-tasks
+        run:
+          path: /bin/bash
+          args:
+            - -c
+            - echo "Not doing anything here... Literally creating an empty vars-files because it's required for the next task"
+        outputs:
+        - name: vars-files
+  - task: create-and-deploy-statsd-injector-release
+    file: cf-deployment-concourse-tasks/bosh-deploy-with-created-release/task.yml
+    input_mapping:
+      toolsmiths-env: cfd-env
+      release: statsd-injector-release
+      ops-files: collected-ops-files
+    params:
+      OPS_FILES: |
+        operations/scale-to-one-az.yml
+        operations/use-compiled-releases.yml
+        operations/experimental/fast-deploy-with-downtime-and-danger.yml
+        operations/add-statsd-injector.yml
+  - task: enable-feature-flags
+    file: cf-deployment-concourse-tasks/set-feature-flags/task.yml
+    input_mapping:
+      toolsmiths-env: cfd-env
+    attempts: 3
+    params:
+      ENABLED_FEATURE_FLAGS: diego_docker
+  - task: cleanup
+    file: cf-deployment-concourse-tasks/bosh-cleanup/task.yml
+    input_mapping:
+      toolsmiths-env: cfd-env
+  - task: create-blackbox-space
+    input_mapping:
+      toolsmiths-env: cfd-env
+    config:
+      platform: linux
+      image_resource:
+        type: docker-image
+        source:
+          repository: relintdockerhubpushbot/cf-deployment-concourse-tasks
+      inputs:
+      - name: toolsmiths-env
+      params:
+        ORG: system
+        SPACE: blackbox-testing
+      run:
+        path: /bin/bash
+        args:
+          - -exc
+          - |
+            API_URL=$(cat toolsmiths-env/metadata | jq -r '.cf.api_url')
+            eval "$(bbl print-env --metadata-file toolsmiths-env/metadata)"
+            password=$(credhub get --name=$(credhub find | grep cf_admin | awk '{print $3}') --output-json | jq -r .value)
+            cf api $API_URL --skip-ssl-validation
+            cf auth admin $password
+            cf target -o system
+
+            set +e
+            cf org $ORG
+            set -e
+            if [ $? -eq 0 ]; then
+              cf create-org $ORG
+            fi
+            cf target -o $ORG
+
+            set +e
+            cf space $SPACE
+            set -e
+            if [ $? -eq 0 ]; then
+              cf create-space $SPACE
+            fi
+  - task: create-accumulators-space
+    file: statsd-injector-release/ci/tasks/create-org-and-space/task.yml
+    input_mapping:
+      toolsmiths-env: cfd-env
+      release: statsd-injector-release
+    params:
+      ORG: system
+      SPACE: accumulators
+
+- name: test-releases-can-be-exported
+  serial: true
+  serial_groups:
+  - bosh-export-releases
+  plan:
+  - in_parallel:
+    - get: concourse-tasks
+    - get: cf-deployment-concourse-tasks-image
+    - get: cfd-env
+      tags: [ ((toolsmiths-workers-tag)) ]
+    - get: statsd-injector-release
+      trigger: true
+      passed: ["cf-deploy"]
+  - do:
+    - task: export-releases-xenial
+      file: concourse-tasks/release/export/task.yml
+      params:
+        RELEASE_NAMES: |
+          statsd-injector
+    ensure:
+      task: clean-up
+      image: cf-deployment-concourse-tasks-image
+      input_mapping:
+        toolsmiths-env: cfd-env
+      config:
+        platform: linux
+        inputs:
+        - name: toolsmiths-env
+        run:
+          path: /bin/bash
+          args:
+          - "-ec"
+          - |
+            eval "$(bbl print-env --metadata-file toolsmiths-env/metadata)"
+            for deployment in $(bosh deployments --column Name | grep compilation-) ; do
+              bosh delete-deployment -d "$deployment" -n
+            done
+- name: cfar-lats
+  serial: true
+  serial_groups:
+  - bosh-cfar-lats
+  plan:
+  - in_parallel:
+    - get: cfar-logging-acceptance-tests
+      trigger: true
+    - get: loggregator-ci
+    - get: cfd-env
+      tags: [ ((toolsmiths-workers-tag)) ]
+    - get: cf-drain-cli-master
+    - get: log-stream-cli-master
+    - get: statsd-injector-release
+      trigger: true
+      passed: ["cf-deploy"]
+  - task: run-cfar-lats
+    input_mapping:
+      cf-drain-cli: cf-drain-cli-master
+      log-stream-cli: log-stream-cli-master
+      toolsmiths-env: cfd-env
+    config:
+      platform: linux
+      image_resource:
+        type: docker-image
+        source:
+          repository: relintdockerhubpushbot/cf-deployment-concourse-tasks
+      inputs:
+      - name: toolsmiths-env
+      - name: cfar-logging-acceptance-tests
+      - name: cf-drain-cli
+      - name: log-stream-cli
+      outputs:
+      - name: cats-config
+      run:
+        path: /bin/bash
+        args:
+          - -exc
+          - |
+            # Target CF
+            api_url=$(cat toolsmiths-env/metadata | jq -r '.cf.api_url')
+            SYSTEM_DOMAIN=${api_url#"api."}
+            eval "$(bbl print-env --metadata-file toolsmiths-env/metadata)"
+            export CF_ADMIN_USER=admin
+            export CF_ADMIN_PASSWORD=$(credhub get --name=$(credhub find | grep cf_admin | awk '{print $3}') --output-json | jq -r .value)
+            export CF_DOMAIN=${SYSTEM_DOMAIN}
+            cf api $api_url --skip-ssl-validation
+            cf auth admin $CF_ADMIN_PASSWORD
+            cf target -o system -s accumulators
+
+            # Move to GOPATH and run ginkto tests
+            mkdir -p $GOPATH/src/github.com/cloudfoundry
+            mkdir -p $GOPATH/src/code.cloudfoundry.org
+
+            cp -R cfar-logging-acceptance-tests $GOPATH/src/github.com/cloudfoundry
+            cp -R cf-drain-cli $GOPATH/src/code.cloudfoundry.org
+            cp -R log-stream-cli $GOPATH/src/github.com/cloudfoundry
+
+            pushd $GOPATH/src/code.cloudfoundry.org/cf-drain-cli
+                go get ./...
+            popd
+
+            pushd $GOPATH/src/code.cloudfoundry.org/cf-drain-cli/cmd/cf-drain-cli
+                go build
+                cf install-plugin -f cf-drain-cli
+            popd
+
+            pushd $GOPATH/src/github.com/cloudfoundry/log-stream-cli
+                go get ./...
+            popd
+
+            pushd $GOPATH/src/github.com/cloudfoundry/log-stream-cli/cmd/log-stream-cli
+                go build
+                cf install-plugin -f ./log-stream-cli
+            popd
+
+            export SKIP_SSL_VALIDATION=true
+            export APP_PUSH_TIMEOUT=180s
+            pushd $GOPATH/src/github.com/cloudfoundry/cfar-logging-acceptance-tests
+              go get -t ./...
+              go install github.com/onsi/ginkgo/ginkgo
+              ginkgo -r -race -flakeAttempts=2 --skip="ServiceDrain"
+            popd
+
+- name: unclaim-cfd-env
+  serial: true
+  plan:
+  - in_parallel:
+    - get: cfd-env
+      passed: ["claim-cfd-env"]
+      tags: [ ((toolsmiths-workers-tag)) ]
+    - put: cfd-env
+      inputs:
+      - cfd-env
+      params:
+        action: unclaim
+        env_file: cfd-env/metadata
+      tags: [ ((toolsmiths-workers-tag)) ]
+
+#==========================================================================================
+#                                    CUT RELEASE
+#==========================================================================================
+- name: statsd-injector-bumper-check
+  serial: true
+  plan:
+  - in_parallel:
+    - get: loggregator-ci
+    - get: statsd-injector-release-master
+      resource: statsd-injector-release-master-to-cut
+      trigger: true
+    - get: statsd-injector-github-release-published
+  - task: diff-master-last-release
+    input_mapping:
+      release: statsd-injector-release-master
+      published-release: statsd-injector-github-release-published
+    file: loggregator-ci/tasks/bumper-check/task.yml
+    params:
+      SSH_KEY: ((loggregator-key))
+      TRACKER_API_TOKEN: ((tracker-api-token))
+
+- name: statsd-injector-cut-patch
+  plan:
+  - put: statsd-injector-version
+    params: {bump: patch}
+- name: statsd-injector-cut-minor
+  plan:
+  - put: statsd-injector-version
+    params: {bump: minor}
+- name: statsd-injector-cut-major
+  plan:
+  - put: statsd-injector-version
+    params: {bump: major}
+
+- name: statsd-injector-create-final-release
+  serial: true
+  plan:
+  - in_parallel:
+    - get: statsd-injector-release-master-version
+    - get: loggregator-ci
+  - task: create-final-release
+    file: loggregator-ci/tasks/create-final-release/master/task.yml
+    input_mapping:
+      master-repo: statsd-injector-release-master-version
+    params:
+      S3_ACCESS_KEY: ((s3-access-key-id))
+      S3_SECRET_KEY: ((s3-secret-access-key))
+      BLOBSTORE_BUCKET: statsd-injector-release-blobs
+      JSON_KEY: ((gcp-service-account-key))
+      SSH_KEY: ((loggregator-key))
+      RELEASE_NAME: Statsd Injector
+      AUTO_BUMPABLE_COMMITS: |
+        'Bump modules'
+        'bump golang release'
+        'Merge final release artifacts'
+        'Create final release'
+        'bump to'
+  - put: statsd-injector-release-master-to-cut
+    params:
+      repository: repos/master-repo
+      rebase: false
+  - try:
+      task: should-publish
+      file: loggregator-ci/tasks/create-final-release/should-publish/task.yml
+      on_success:
+        put: statsd-injector-github-release-published
+        params:
+          name: github-release/name
+          tag: github-release/tag
+          body: github-release/body
+          globs:
+          - github-release/*.tgz
+      on_failure:
+        put: statsd-injector-github-release-drafts
+        params:
+          name: github-release/name
+          tag: github-release/tag
+          body: github-release/body
+          globs:
+            - github-release/*.tgz
+
+- name: statsd-injector-merge-to-develop
+  serial: true
+  plan:
+  - in_parallel:
+    - get: statsd-injector-release
+      resource: statsd-injector-release-to-cut
+    - get: statsd-injector-release-master
+      resource: statsd-injector-release-master-to-cut
+      passed: [ statsd-injector-create-final-release ]
+      trigger: true
+    - get: loggregator-ci
+    - get: statsd-injector-github-release-published
+      trigger: true
+  - task: wait-for-releases-to-match
+    input_mapping:
+      master-repo: statsd-injector-release-master
+      published-release: statsd-injector-github-release-published
+    config:
+      image_resource:
+        type: docker-image
+        source:
+          repository: loggregator/base
+      platform: linux
+      inputs:
+        - name: master-repo
+        - name: published-release
+      run:
+        path: /bin/bash
+        args:
+          - "-c"
+          - |
+            set -e
+
+            pushd master-repo > /dev/null
+              master_sha=$(git rev-parse HEAD)
+            popd
+
+            published_sha=$(cat published-release/commit_sha)
+
+            if [[ ${master_sha} != ${published_sha} ]]; then
+              echo "Published release sha doesn't match master repo sha"
+              echo "This job will retrigger once published release or master repo resource is updated"
+              exit 1
+            fi
+  - task: merge-back-to-develop
+    file: loggregator-ci/tasks/merge-to-develop/task.yml
+    input_mapping:
+      master-repo: statsd-injector-release-master
+      develop-repo: statsd-injector-release
+    params:
+      SSH_KEY: ((loggregator-key))
+      MASTER_BRANCH: master
+      DEVELOP_BRANCH: develop
+  - put: statsd-injector-release-to-cut
+    params:
+      repository: repos/develop-repo
+      rebase: false
+
+#==========================================================================================
+#                                  BUMP DEPENDENCIES
+#==========================================================================================
+- name: bump-golang
+  serial: true
+  plan:
+  - in_parallel:
+    - get: loggregator-ci
+    - get: concourse-tasks
+    - get: golang-release
+      trigger: true
+    - get: statsd-injector-release
+      resource: statsd-injector-release-to-cut
+  - in_parallel:
+    - do:
+      - task: bump-statsd-injector-release
+        file: concourse-tasks/go/bump-vendored-golang/task.yml
+        input_mapping:
+          release: statsd-injector-release
+        output_mapping:
+          output-repo: updated-statsd-injector-release
+        params:
+          BLOBSTORE_ACCESS_KEY_ID: {{s3-access-key-id}}
+          BLOBSTORE_SECRET_ACCESS_KEY: {{s3-secret-access-key}}
+          GCS_JSON_KEY: {{gcp-service-account-key}}
+          GIT_USER_EMAIL: cf-loggregator@pivotal.io
+          GIT_USER_NAME: Loggregator CI
+          GOLANG_DIR: golang-release
+          RELEASE_DIR: release
+      - put: statsd-injector-release
+        params:
+          repository: updated-statsd-injector-release
+          rebase: false
+

--- a/ci/pipelines/statsd-injector.yml
+++ b/ci/pipelines/statsd-injector.yml
@@ -63,7 +63,7 @@ resources:
 - name: cfar-logging-acceptance-tests
   type: git
   source:
-    branch: statsd-metrics # TODO: change back to master!
+    branch: master
     uri: https://github.com/cloudfoundry/cfar-logging-acceptance-tests.git
 
 - name: denver-deployments
@@ -100,7 +100,7 @@ resources:
   type: git
   source:
     uri: git@github.com:cloudfoundry/statsd-injector-release.git
-    branch: lts-pipeline # TODO: change me back to develop!
+    branch: develop
     private_key: ((cf-loggregator-oauth-bot-key))
     ignore_paths:
       - .final_builds
@@ -349,45 +349,13 @@ jobs:
     input_mapping:
       toolsmiths-env: cfd-env
   - task: create-blackbox-space
+    file: statsd-injector-release/ci/tasks/create-org-and-space/task.yml
     input_mapping:
       toolsmiths-env: cfd-env
-    config:
-      platform: linux
-      image_resource:
-        type: docker-image
-        source:
-          repository: relintdockerhubpushbot/cf-deployment-concourse-tasks
-      inputs:
-      - name: toolsmiths-env
-      params:
-        ORG: system
-        SPACE: blackbox-testing
-      run:
-        path: /bin/bash
-        args:
-          - -exc
-          - |
-            API_URL=$(cat toolsmiths-env/metadata | jq -r '.cf.api_url')
-            eval "$(bbl print-env --metadata-file toolsmiths-env/metadata)"
-            password=$(credhub get --name=$(credhub find | grep cf_admin | awk '{print $3}') --output-json | jq -r .value)
-            cf api $API_URL --skip-ssl-validation
-            cf auth admin $password
-            cf target -o system
-
-            set +e
-            cf org $ORG
-            set -e
-            if [ $? -eq 0 ]; then
-              cf create-org $ORG
-            fi
-            cf target -o $ORG
-
-            set +e
-            cf space $SPACE
-            set -e
-            if [ $? -eq 0 ]; then
-              cf create-space $SPACE
-            fi
+      release: statsd-injector-release
+    params:
+      ORG: system
+      SPACE: blackbox-testing
   - task: create-accumulators-space
     file: statsd-injector-release/ci/tasks/create-org-and-space/task.yml
     input_mapping:
@@ -701,7 +669,7 @@ jobs:
           GIT_USER_NAME: Loggregator CI
           GOLANG_DIR: golang-release
           RELEASE_DIR: release
-      - put: statsd-injector-release
+      - put: statsd-injector-release-to-cut
         params:
           repository: updated-statsd-injector-release
           rebase: false

--- a/ci/set-pipeline.sh
+++ b/ci/set-pipeline.sh
@@ -1,0 +1,69 @@
+#!/bin/bash
+set -eo pipefail
+
+function set_globals {
+    pipeline=$1
+    TARGET="${TARGET:-denver}"
+    TEAM="${TEAM:-loggregator}"
+    FLY_URL="https://concourse.cf-denver.com/"
+    PIPELINES_DIR="$(dirname $0)/pipelines"
+}
+
+function validate {
+    if [[ "$pipeline" = "-h" ]] || [[ "$pipeline" = "--help" ]] || [[ -z "$pipeline" ]]; then
+        print_usage
+        exit 1
+    fi
+}
+
+function set_pipeline {
+    pipeline_name=$1
+    pipeline_file="${PIPELINES_DIR}/$(ls ${PIPELINES_DIR} | grep ^${pipeline_name})"
+
+    if [[ ${pipeline_file} = *.erb ]]; then
+      erb ${pipeline_file} > /dev/null # this way if the erb fails the script bails
+    fi
+
+    echo setting pipeline for "$pipeline_name"
+
+    fly -t ${TARGET} set-pipeline -p "$pipeline_name" \
+        -c <(erb ${pipeline_file}) \
+        -l <(lpass show 'Shared-Loggregator (Pivotal Only)/pipeline-secrets.yml' --notes) \
+        -l <(lpass show 'Shared-CF-Log Cache (Pivotal ONLY)/release-credentials.yml' --notes) \
+        -l <(lpass show 'Shared-Pivotal Common/pas-releng-fetch-releases' --notes) \
+        --var "toolsmiths-api-key=$(lpass show 'Shared-Loggregator (Pivotal Only)/toolsmiths-api-token' --notes)" \
+        -l ${PIPELINES_DIR}/config/config.yml
+}
+
+function sync_fly {
+    if ! fly -t ${TARGET} status; then
+      fly -t ${TARGET} login -n ${TEAM} -b -c ${FLY_URL}
+    fi
+    fly -t ${TARGET} sync
+}
+
+function set_pipelines {
+    if [[ "$pipeline" = all ]]; then
+        for pipeline_path in $(find ${PIPELINES_DIR} -maxdepth 1 -type f); do
+          pipeline_file=$(basename ${pipeline_path})
+          set_pipeline "${pipeline_file%%.*}"
+        done
+        exit 0
+    fi
+
+    set_pipeline "$pipeline"
+}
+
+function print_usage {
+    echo "usage: $0 <pipeline | all>"
+}
+
+function main {
+    set_globals $1
+    validate
+    sync_fly
+    set_pipelines
+}
+
+lpass ls 1>/dev/null
+main $1 $2

--- a/ci/tasks/create-org-and-space/task
+++ b/ci/tasks/create-org-and-space/task
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+set -ex
+
+source release/ci/tasks/environment-targeting.sh
+
+set +e
+cf org $ORG
+set -e
+
+if [ $? -eq 0 ]; then
+      cf create-org $ORG
+fi
+
+cf target -o $ORG
+
+set +e
+cf space $SPACE
+set -e
+
+if [ $? -eq 0 ]; then
+      cf create-space $SPACE
+fi
+
+cf target -s $SPACE
+

--- a/ci/tasks/create-org-and-space/task.yml
+++ b/ci/tasks/create-org-and-space/task.yml
@@ -1,0 +1,17 @@
+platform: linux
+
+image_resource:
+  type: docker-image
+  source:
+    repository: relintdockerhubpushbot/cf-deployment-concourse-tasks
+
+inputs:
+- name: toolsmiths-env
+- name: release
+
+params:
+  ORG:
+  SPACE:
+
+run:
+  path: release/ci/tasks/create-org-and-space/task

--- a/ci/tasks/environment-targeting.sh
+++ b/ci/tasks/environment-targeting.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+API_URL=$(cat toolsmiths-env/metadata | jq -r '.cf.api_url')
+eval "$(bbl print-env --metadata-file toolsmiths-env/metadata)"
+password=$(credhub get --name=$(credhub find | grep cf_admin | awk '{print $3}') --output-json | jq -r .value)
+cf api $API_URL --skip-ssl-validation
+cf auth admin $password
+cf target -o system

--- a/manifests/operations/add-statsd-injector.yml
+++ b/manifests/operations/add-statsd-injector.yml
@@ -1,0 +1,30 @@
+- type: replace
+  path: /releases/name=statsd-injector?
+  value:
+    name: statsd-injector
+    version: latest
+
+- type: replace
+  path: /instance_groups/name=doppler/jobs/name=statsd_injector?
+  value:
+    name: statsd_injector
+    release: statsd-injector
+    properties:
+      loggregator:
+        tls:
+          ca_cert: "((statsd_injector.ca))"
+          statsd_injector:
+            cert: "((statsd_injector.certificate))"
+            key: "((statsd_injector.private_key))"
+
+- type: replace
+  path: /variables/name=statsd_injector?
+  value:
+    name: statsd_injector
+    type: certificate
+    options:
+      ca: loggregator_ca
+      common_name: statsdinjector
+      extended_key_usage:
+      - client_auth
+

--- a/src/go.mod
+++ b/src/go.mod
@@ -12,8 +12,8 @@ require (
 	github.com/onsi/ginkgo v1.13.0
 	github.com/onsi/gomega v1.10.1
 	golang.org/x/net v0.0.0-20200602114024-627f9648deb9
-	golang.org/x/sys v0.0.0-20200610111108-226ff32320da // indirect
-	google.golang.org/genproto v0.0.0-20200612171551-7676ae05be11 // indirect
+	golang.org/x/sys v0.0.0-20200615200032-f1bc736245b1 // indirect
+	google.golang.org/genproto v0.0.0-20200615140333-fd031eab31e7 // indirect
 	google.golang.org/grpc v1.29.1
 	gopkg.in/check.v1 v1.0.0-20200227125254-8fa46927fb4f // indirect
 )

--- a/src/go.sum
+++ b/src/go.sum
@@ -100,8 +100,8 @@ golang.org/x/sys v0.0.0-20191120155948-bd437916bb0e/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd h1:xhmwyvizuTgC2qz7ZlMluP20uW+C3Rm0FD/WLDX8884=
 golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200519105757-fe76b779f299/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20200610111108-226ff32320da h1:bGb80FudwxpeucJUjPYJXuJ8Hk91vNtfvrymzwiei38=
-golang.org/x/sys v0.0.0-20200610111108-226ff32320da/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20200615200032-f1bc736245b1 h1:ogLJMz+qpzav7lGMh10LMvAkM/fAoGlaiiHYiFYdm80=
+golang.org/x/sys v0.0.0-20200615200032-f1bc736245b1/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.3.0 h1:g61tztE5qeGQ89tm6NTjjM9VPIm088od1l6aSorWRWg=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.2 h1:tW2bmiBqwgJj/UpqtC8EpXEZVYOwU0yG4iWbprSVAcs=
@@ -120,8 +120,8 @@ google.golang.org/genproto v0.0.0-20180817151627-c66870c02cf8 h1:Nw54tB0rB7hY/N0
 google.golang.org/genproto v0.0.0-20180817151627-c66870c02cf8/go.mod h1:JiN7NxoALGmiZfu7CAH4rXhgtRTLTxftemlI0sWmxmc=
 google.golang.org/genproto v0.0.0-20190819201941-24fa4b261c55/go.mod h1:DMBHOl98Agz4BDEuKkezgsaosCRResVns1a3J2ZsMNc=
 google.golang.org/genproto v0.0.0-20200526211855-cb27e3aa2013/go.mod h1:NbSheEEYHJ7i3ixzK3sjbqSGDJWnxyFXZblF3eUsNvo=
-google.golang.org/genproto v0.0.0-20200612171551-7676ae05be11 h1:II66Di7x1uAfKBfe3OchemS7pUg9ahSr7qAP3bD0+Mo=
-google.golang.org/genproto v0.0.0-20200612171551-7676ae05be11/go.mod h1:jDfRM7FcilCzHH/e9qn6dsT145K34l5v+OpcnNgKAAA=
+google.golang.org/genproto v0.0.0-20200615140333-fd031eab31e7 h1:1N7l1PuXZwEK7OhHdmKQROOM75PnUjABGwvVRbLBgFk=
+google.golang.org/genproto v0.0.0-20200615140333-fd031eab31e7/go.mod h1:jDfRM7FcilCzHH/e9qn6dsT145K34l5v+OpcnNgKAAA=
 google.golang.org/grpc v1.19.0/go.mod h1:mqu4LbDTu4XGKhr4mRzUsmM4RtVoemTSY81AxZiDr8c=
 google.golang.org/grpc v1.23.0/go.mod h1:Y5yQAOtifL1yxbo5wqy6BxZv8vAUGQwXBOALyacEbxg=
 google.golang.org/grpc v1.25.1/go.mod h1:c3i+UQWmh7LiEpx4sFZnkU36qjEYZ0imhYfXVyQciAY=

--- a/src/vendor/modules.txt
+++ b/src/vendor/modules.txt
@@ -66,7 +66,7 @@ golang.org/x/net/http2/hpack
 golang.org/x/net/idna
 golang.org/x/net/internal/timeseries
 golang.org/x/net/trace
-# golang.org/x/sys v0.0.0-20200610111108-226ff32320da
+# golang.org/x/sys v0.0.0-20200615200032-f1bc736245b1
 golang.org/x/sys/internal/unsafeheader
 golang.org/x/sys/unix
 # golang.org/x/text v0.3.2
@@ -93,7 +93,7 @@ golang.org/x/text/unicode/norm
 # golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543
 golang.org/x/xerrors
 golang.org/x/xerrors/internal
-# google.golang.org/genproto v0.0.0-20200612171551-7676ae05be11
+# google.golang.org/genproto v0.0.0-20200615140333-fd031eab31e7
 google.golang.org/genproto/googleapis/rpc/status
 # google.golang.org/grpc v1.29.1
 google.golang.org/grpc


### PR DESCRIPTION
* Includes product testing, cutting release, and bumping golang
  * bump-golang task currently failing in the pipeline probably because we're pointing at different branches that have changes
* This uses a Toolsmiths cfd-env
  * note that this requires a special tag in order to use a concourse worker in the pivotal network
  * this pipeline lives in https://concourse.cf-denver.com/ because loggregator concourse does not have a worker in the pivotal network
* Pinned some resources to avoid future breakages
* Make set-pipeline script able to run from root
* Update README to use log stream plugin instead

* skip ServiceDrain tests in cfar-lats as it constantly fails and is
unrelated to testing statsd
* use statsd-metrics branch of cfar-lats which includes a log-stream
test to check for statsd uaa metrics. this can be removed once this PR
is in:
cloudfoundry/cfar-logging-acceptance-tests#4

[#172180410]