### PR TITLE
Fix: deprecated gRPC functions

### DIFF
--- a/src/component_tests/statsd_injector_test.go
+++ b/src/component_tests/statsd_injector_test.go
@@ -2,7 +2,6 @@ package component_tests_test
 
 import (
 	"fmt"
-	"log"
 	"net"
 	"os/exec"
 	"time"
@@ -24,7 +23,8 @@ var _ = Describe("StatsdInjector", func() {
 	)
 
 	BeforeSuite(func() {
-		grpclog.SetLogger(log.New(GinkgoWriter, "", 0))
+		g := grpclog.NewLoggerV2(GinkgoWriter, GinkgoWriter, GinkgoWriter)
+		grpclog.SetLoggerV2(g)
 	})
 
 	BeforeEach(func() {

--- a/src/internal/egress/emitter_test.go
+++ b/src/internal/egress/emitter_test.go
@@ -7,6 +7,7 @@ import (
 	"code.cloudfoundry.org/go-loggregator/v8/rpc/loggregator_v2"
 	"github.com/cloudfoundry/statsd-injector/internal/egress"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -35,7 +36,8 @@ var _ = Describe("Statsdemitter", func() {
 	Context("when the server is already listening", func() {
 		BeforeEach(func() {
 			serverAddr, mockServer = startServer()
-			emitter := egress.New(serverAddr, grpc.WithInsecure())
+			dialOpt := grpc.WithTransportCredentials(insecure.NewCredentials())
+			emitter := egress.New(serverAddr, dialOpt)
 
 			go emitter.Run(inputChan)
 		})


### PR DESCRIPTION
# Description

Only changes tests. We use two gRPC functions that are deprecated. This replaces them with the new functions.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Testing performed?

- [x] Unit tests
- [ ] Integration tests
- [ ] Acceptance tests

## Checklist:

- [x] This PR is being made against the `main` branch, or relevant version branch
- [ ] I have made corresponding changes to the documentation
- [ ] I have added testing for my changes