### PR TITLE
Fix: Remove ginkgo CLI from tools depencies

### DIFF
--- a/src/tools.go
+++ b/src/tools.go
@@ -5,5 +5,4 @@ package main
 
 import (
 	_ "git.sr.ht/~nelsam/hel/v3"
-	_ "github.com/onsi/ginkgo/v2/ginkgo"
 )


### PR DESCRIPTION
Ginkgo imports its own CLI by default now, so it no longer needs to be
specified by us as a tools depedency.
