### PR TITLE
CI: Fix GH actions by specifying Go version

### DIFF
--- a/.github/workflows/scripts.yml
+++ b/.github/workflows/scripts.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version-file: "src/go.mod"
+          go-version: '1.21'
       - run: ./scripts/subtests/unit-test
 
   lint:
@@ -24,5 +24,5 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version-file: "src/go.mod"
+          go-version: '1.21'
       - run: ./scripts/subtests/lint


### PR DESCRIPTION
Use the latest go1.21 version to fix failing GH actions resulting from picking go1.21.0 and then upgrading to go1.21.9.